### PR TITLE
Bump dependencies 002700->002702

### DIFF
--- a/src/dotnet-test-xunit/project.json
+++ b/src/dotnet-test-xunit/project.json
@@ -41,7 +41,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.0-rc2-3002700",
+          "version": "1.0.0-rc2-3002702",
           "type": "platform"
         }
       }
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview1-002700",
+    "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview1-002702",
     "xunit.runner.reporters": "2.1.0"
   }
 }

--- a/test/dotnet-test-xunit.Tests/project.json
+++ b/test/dotnet-test-xunit.Tests/project.json
@@ -8,7 +8,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.0-rc2-3002700",
+          "version": "1.0.0-rc2-3002702",
           "type": "platform"
         }
       }


### PR DESCRIPTION
Bumps dependencies on https://github.com/dotnet/cli to the latest preview1 version.