### PR TITLE
Emdbedded pdb support

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "projects": [ "src", "test" ],
     "sdk": {
-        "version": "1.0.0-preview2-003121"
+        "version": "1.0.0-preview3-003555"
     }
 }

--- a/src/dotnet-test-xunit/Program.cs
+++ b/src/dotnet-test-xunit/Program.cs
@@ -542,13 +542,7 @@ namespace Xunit.Runner.DotNet
 
         private static ISourceInformationProvider GetSourceInformationProviderAdapater(XunitProjectAssembly assembly)
         {
-            var directoryPath = Path.GetDirectoryName(assembly.AssemblyFilename);
-            var assemblyName = Path.GetFileNameWithoutExtension(assembly.AssemblyFilename);
-            var pdbPath = Path.Combine(directoryPath, assemblyName + FileNameSuffixes.DotNet.ProgramDatabase);
-
-            return File.Exists(pdbPath)
-                ? new SourceInformationProviderAdapater(new SourceInformationProvider(pdbPath))
-                : null;
+            return new SourceInformationProviderAdapater(new SourceInformationProvider(assembly.AssemblyFilename));
         }
 
         static Task<T> TaskRun<T>(Func<T> function)

--- a/src/dotnet-test-xunit/project.json
+++ b/src/dotnet-test-xunit/project.json
@@ -52,7 +52,7 @@
         }
     },
     "dependencies": {
-        "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview2-003121",
+        "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview3-003555",
         "xunit.runner.reporters": "2.2.0-beta3-build3342"
     }
 }


### PR DESCRIPTION
SourceInformationProvider now supports retrieving PDB from the PE file itself - it uses the PE Debug Directory Entry information to locate the PDB, which can be next to the PE file or embedded in the PE file itself.
Pass the path to the DLL directly to SourceInformationProvider constructor, which now accepts path to the PE file as well as path to the PDB.

See commit in dotnet/cli repo: https://github.com/dotnet/cli/pull/4108/commits/9193802cc3d03976d6df6a055843fe778e2b84ba

TODO: dotnet cli 1.0.0-preview3-003555 is not on nuget.org yet, so restore fails currently